### PR TITLE
Fix crash when switching NFS3 cars

### DIFF
--- a/NFS3/NFS3Loader.cpp
+++ b/NFS3/NFS3Loader.cpp
@@ -49,7 +49,7 @@ namespace LibOpenNFS::NFS3 {
         if (pos != std::string::npos) {
             trackNameStripped.replace(pos, strip.size(), "");
         }
-        Track track(NFSVersion::NFS_3, trackNameStripped, trackBasePath);
+        Track track(NFSVersion::NFS_3, trackName, trackBasePath);
 
         frdPath = trackBasePath + "/" + trackNameStripped + ".frd";
         colPath = trackBasePath + "/" + trackNameStripped + ".col";
@@ -145,6 +145,11 @@ namespace LibOpenNFS::NFS3 {
                                                                  std::string const &trackOutPath) {
         std::map<uint32_t, TrackTextureAsset> textureAssetMap;
         size_t max_width{0}, max_height{0};
+        std::string strip = "k0", trackNameStripped = track.name;
+        size_t pos = track.name.find(strip);
+        if (pos != std::string::npos) {
+            trackNameStripped.replace(pos, strip.size(), "");
+        }
 
         // Load QFS texture information into ONFS texture objects
         for (auto &frdTexBlock : frdFile.textureBlocks) {
@@ -166,9 +171,9 @@ namespace LibOpenNFS::NFS3 {
                 fileReference << "../resources/sfx/" << std::setfill('0') << std::setw(4) << frdTexBlock.qfsIndex + 9 << ".BMP";
                 alphaFileReference << "../resources/sfx/" << std::setfill('0') << std::setw(4) << frdTexBlock.qfsIndex + 9 << "-a.BMP";
             } else {
-                fileReference << trackOutPath << "/" << track.name << "/textures/" << std::setfill('0') << std::setw(4)
+                fileReference << trackOutPath << "/" << trackNameStripped << "/textures/" << std::setfill('0') << std::setw(4)
                               << frdTexBlock.qfsIndex << ".BMP";
-                alphaFileReference << trackOutPath << "/" << track.name << "/textures/" << std::setfill('0') << std::setw(4)
+                alphaFileReference << trackOutPath << "/" << trackNameStripped << "/textures/" << std::setfill('0') << std::setw(4)
                                    << frdTexBlock.qfsIndex << "-a.BMP";
             }
 


### PR DESCRIPTION
Right now switching cars on the dev branch of OpenNFS crashes. I found that this happens, because the stripped track name is saved in the track entity. After changing this I found that textures were not loading because they relied on the stripped name, so I added a bit of code to the `_ParseTextures` function to also strip the name. Now textures load and the game does not crash when switching cars.