### PR TITLE
Load alpha and secondary colors nfs3

### DIFF
--- a/Common/TextureUtils.cpp
+++ b/Common/TextureUtils.cpp
@@ -20,11 +20,13 @@ namespace LibOpenNFS {
 
     // Convert hsv floats ([0-1],[0-1],[0-1]) to rgb floats ([0-1],[0-1],[0-1]), from Foley & van Dam p593
     // also http://en.wikipedia.org/wiki/HSL_and_HSV
-    glm::vec3 TextureUtils::HSLToRGB(glm::vec4 hsl) {
+    glm::vec4 TextureUtils::HSLToRGB(glm::vec4 hsl) {
         float h = hsl.x / 255.f;
         float s = hsl.y / 255.f;
         float v = hsl.z / 255.f;
-        glm::vec3 rgb;
+        float a = hsl.a / 255.f;
+        glm::vec4 rgb;
+        rgb.a = a;
 
         if (s == 0.0f) {
             // gray

--- a/Common/TextureUtils.h
+++ b/Common/TextureUtils.h
@@ -14,7 +14,7 @@ namespace LibOpenNFS {
     class TextureUtils {
     public:
         static uint32_t abgr1555ToARGB8888(uint16_t abgr_1555);
-        static glm::vec3 HSLToRGB(glm::vec4 hsl);
+        static glm::vec4 HSLToRGB(glm::vec4 hsl);
         static glm::vec3 ParseRGBString(const std::string &rgb_string);
         // Break Packed uint32_t RGBA per vertex colour data for baked lighting of RGB into 4 normalised floats and store into vec4
         static glm::vec4 ShadingDataToVec4(uint32_t packed_rgba);

--- a/Entities/Car.h
+++ b/Entities/Car.h
@@ -22,9 +22,9 @@ namespace LibOpenNFS {
         class Colour {
         public:
             std::string colourName;
-            glm::vec3 colour;
-            glm::vec3 colourSecondary;
-            Colour(const std::string& colourName, const glm::vec3 colour, const glm::vec3 colourSecondary = {0.0, 0.0, 0.0}) {
+            glm::vec4 colour;
+            glm::vec4 colourSecondary;
+            Colour(const std::string& colourName, const glm::vec4 colour, const glm::vec4 colourSecondary = {0.0, 0.0, 0.0, 0.0}) {
                 this->colourName = colourName;
                 this->colour     = colour;
                 this->colourSecondary = colourSecondary;

--- a/Entities/Car.h
+++ b/Entities/Car.h
@@ -23,9 +23,11 @@ namespace LibOpenNFS {
         public:
             std::string colourName;
             glm::vec3 colour;
-            Colour(const std::string& colourName, const glm::vec3 colour) {
+            glm::vec3 colourSecondary;
+            Colour(const std::string& colourName, const glm::vec3 colour, const glm::vec3 colourSecondary = {0.0, 0.0, 0.0}) {
                 this->colourName = colourName;
                 this->colour     = colour;
+                this->colourSecondary = colourSecondary;
             }
         };
 

--- a/NFS3/NFS3Loader.cpp
+++ b/NFS3/NFS3Loader.cpp
@@ -96,8 +96,9 @@ namespace LibOpenNFS::NFS3 {
 
         // Grab colours
         for (uint8_t colourIdx = 0; colourIdx < fceFile.nPriColours; ++colourIdx) {
-            auto [H, S, B, T] = fceFile.primaryColours[colourIdx];
-            Car::Colour originalPrimaryColour(fedataFile.primaryColourNames[colourIdx], TextureUtils::HSLToRGB(glm::vec4(H, S, B, T)));
+            auto [Hp, Sp, Bp, Tp] = fceFile.primaryColours[colourIdx];
+            auto [Hs, Ss, Bs, Ts] = fceFile.secondaryColours[colourIdx];
+            Car::Colour originalPrimaryColour(fedataFile.primaryColourNames[colourIdx], TextureUtils::HSLToRGB(glm::vec4(Hp, Sp, Bp, Tp)), TextureUtils::HSLToRGB(glm::vec4(Hs, Ss, Bs, Ts)));
             carMetadata.colours.emplace_back(originalPrimaryColour);
         }
 


### PR DESCRIPTION
This requires changes in OpenNFS as well. I'll make a PR for that as well.

Basically, the alpha of the car color is used to increase the brightness of the color on the car, so we do need it. There is also a secondary color.