### PR TITLE
Clean up loading track when changing car code

### DIFF
--- a/Entities/Track.cpp
+++ b/Entities/Track.cpp
@@ -1,7 +1,10 @@
 #include "Track.h"
 
 namespace LibOpenNFS {
-    Track::Track(NFSVersion _nfsVersion, std::string const &_name, std::string const &_basePath)
-        : nfsVersion(_nfsVersion), name(_name), basePath(_basePath) {
+    Track::Track(NFSVersion _nfsVersion, std::string const &_name, std::string const &_basePath, std::string const &_tag)
+        : nfsVersion(_nfsVersion), name(_name), basePath(_basePath), tag(_tag) {
+        if (tag.empty()) {
+            tag = name;
+        }
     }
 } // namespace LibOpenNFS

--- a/Entities/Track.h
+++ b/Entities/Track.h
@@ -14,13 +14,14 @@
 namespace LibOpenNFS {
     class Track {
 public:
-    Track(NFSVersion _nfsVersion, std::string const& _name, std::string const& _basePath);
+    Track(NFSVersion _nfsVersion, std::string const& _name, std::string const& _basePath, std::string const& _tag = "");
     Track() = default;
 
     // Metadata
     NFSVersion nfsVersion{};
     std::string name;
     std::string basePath;
+    std::string tag;
     uint32_t nBlocks{0};
     std::vector<Shared::CameraAnimPoint> cameraAnimation;
     std::vector<TrackVRoad> virtualRoad;

--- a/NFS3/NFS3Loader.cpp
+++ b/NFS3/NFS3Loader.cpp
@@ -49,7 +49,7 @@ namespace LibOpenNFS::NFS3 {
         if (pos != std::string::npos) {
             trackNameStripped.replace(pos, strip.size(), "");
         }
-        Track track(NFSVersion::NFS_3, trackName, trackBasePath);
+        Track track(NFSVersion::NFS_3, trackNameStripped, trackBasePath, trackName);
 
         frdPath = trackBasePath + "/" + trackNameStripped + ".frd";
         colPath = trackBasePath + "/" + trackNameStripped + ".col";
@@ -146,11 +146,6 @@ namespace LibOpenNFS::NFS3 {
                                                                  std::string const &trackOutPath) {
         std::map<uint32_t, TrackTextureAsset> textureAssetMap;
         size_t max_width{0}, max_height{0};
-        std::string strip = "k0", trackNameStripped = track.name;
-        size_t pos = track.name.find(strip);
-        if (pos != std::string::npos) {
-            trackNameStripped.replace(pos, strip.size(), "");
-        }
 
         // Load QFS texture information into ONFS texture objects
         for (auto &frdTexBlock : frdFile.textureBlocks) {
@@ -172,9 +167,9 @@ namespace LibOpenNFS::NFS3 {
                 fileReference << "../resources/sfx/" << std::setfill('0') << std::setw(4) << frdTexBlock.qfsIndex + 9 << ".BMP";
                 alphaFileReference << "../resources/sfx/" << std::setfill('0') << std::setw(4) << frdTexBlock.qfsIndex + 9 << "-a.BMP";
             } else {
-                fileReference << trackOutPath << "/" << trackNameStripped << "/textures/" << std::setfill('0') << std::setw(4)
+                fileReference << trackOutPath << "/" << track.name << "/textures/" << std::setfill('0') << std::setw(4)
                               << frdTexBlock.qfsIndex << ".BMP";
-                alphaFileReference << trackOutPath << "/" << trackNameStripped << "/textures/" << std::setfill('0') << std::setw(4)
+                alphaFileReference << trackOutPath << "/" << track.name << "/textures/" << std::setfill('0') << std::setw(4)
                                    << frdTexBlock.qfsIndex << "-a.BMP";
             }
 


### PR DESCRIPTION
The solution I had before was not fully working. It fixed the issue, but caused issues when switching track. This PR comes with an alternative solution which only needs a very small change in OpenNFS.